### PR TITLE
GH-714: As a user I need even better error reporting for external libraries and last changes to support user access on node_modules folder

### DIFF
--- a/npm/async-throttle/0.0.1-incomplete/manifest.n4mf
+++ b/npm/async-throttle/0.0.1-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: async-throttle
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 0.0.1-incomplete
 VendorId: npm
 Output: "."

--- a/npm/bignumber.js/2.4.0-incomplete/manifest.n4mf
+++ b/npm/bignumber.js/2.4.0-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: bignumber.js
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 2.4.0-incomplete
 VendorId: npm
 Output: "."

--- a/npm/body-parser/1.18.2/manifest.n4mf
+++ b/npm/body-parser/1.18.2/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: body-parser
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 16.0.0
 VendorId: npm
 Output: "."

--- a/npm/cheerio/1.0.0/manifest.n4mf
+++ b/npm/cheerio/1.0.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: cheerio
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.0.0
 VendorId: npm
 Output: "."

--- a/npm/chromedriver/2.33.2/manifest.n4mf
+++ b/npm/chromedriver/2.33.2/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: chromedriver
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 2.33.2
 VendorId: npm
 Output: "."

--- a/npm/cli-color/1.1.0-incomplete/manifest.n4mf
+++ b/npm/cli-color/1.1.0-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: cli-color
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.1.0-incomplete
 VendorId: npm
 Output: "."

--- a/npm/cookie-parser/1.4.3/manifest.n4mf
+++ b/npm/cookie-parser/1.4.3/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: cookie-parser
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.4.3
 VendorId: npm
 Output: "."

--- a/npm/cors/2.8.4/manifest.n4mf
+++ b/npm/cors/2.8.4/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: cors
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 2.8.4
 VendorId: npm
 Output: "."

--- a/npm/debug/3.1.0/manifest.n4mf
+++ b/npm/debug/3.1.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: debug
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 3.1.0
 VendorId: npm
 Output: "."

--- a/npm/deep-equal/1.0.1-incomplete/manifest.n4mf
+++ b/npm/deep-equal/1.0.1-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: deep-equal
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.0.1-incomplete
 VendorId: npm
 Output: "."

--- a/npm/enzyme-adapter-react-16/1.1.0/manifest.n4mf
+++ b/npm/enzyme-adapter-react-16/1.1.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: enzyme-adapter-react-16
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.1.0
 VendorId: npm
 Output: "."

--- a/npm/enzyme/3.2.0/manifest.n4mf
+++ b/npm/enzyme/3.2.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: enzyme
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 3.2.0
 VendorId: npm
 Output: "."

--- a/npm/express/4.0.0-incomplete/manifest.n4mf
+++ b/npm/express/4.0.0-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: express
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 4.0.0-incomplete
 VendorId: npm
 Output: "."

--- a/npm/fetch-mock/5.13.1/manifest.n4mf
+++ b/npm/fetch-mock/5.13.1/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: fetch-mock
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 5.13.1
 VendorId: npm
 Output: "."

--- a/npm/fs-extra/4.0.2/manifest.n4mf
+++ b/npm/fs-extra/4.0.2/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: fs-extra
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 4.0.2
 VendorId: npm
 Output: "."

--- a/npm/geckodriver/1.10.0/manifest.n4mf
+++ b/npm/geckodriver/1.10.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: geckodriver
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.10.0
 VendorId: npm
 Output: "."

--- a/npm/glamor/2.20.40/manifest.n4mf
+++ b/npm/glamor/2.20.40/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: glamor
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 2.20.40
 VendorId: npm
 Output: "."

--- a/npm/glob/7.1.2/manifest.n4mf
+++ b/npm/glob/7.1.2/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: glob
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 7.1.2
 VendorId: npm
 Output: "."

--- a/npm/http-proxy-middleware/0.17.4/manifest.n4mf
+++ b/npm/http-proxy-middleware/0.17.4/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: http-proxy-middleware
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 0.17.4
 VendorId: npm
 Output: "."

--- a/npm/immutable/3.8.2/manifest.n4mf
+++ b/npm/immutable/3.8.2/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: immutable
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 3.8.2
 VendorId: npm
 Output: "."

--- a/npm/js-cookie/2.2.0/manifest.n4mf
+++ b/npm/js-cookie/2.2.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: js-cookie
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 2.2.0
 VendorId: npm
 Output: "."

--- a/npm/jsdom/11.5.1/manifest.n4mf
+++ b/npm/jsdom/11.5.1/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: jsdom
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 11.5.1
 VendorId: npm
 Output: "."

--- a/npm/json-cycle/1.0.5-incomplete/manifest.n4mf
+++ b/npm/json-cycle/1.0.5-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: json-cycle
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.0.5-incomplete
 VendorId: npm
 Output: "."

--- a/npm/lodash/4.16.3-incomplete/manifest.n4mf
+++ b/npm/lodash/4.16.3-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: lodash
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 4.16.3-incomplete
 VendorId: npm
 Output: "."

--- a/npm/moment-timezone/0.5.5-incomplete/manifest.n4mf
+++ b/npm/moment-timezone/0.5.5-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: moment-timezone
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 0.5.5-incomplete
 VendorId: npm
 Output: "."

--- a/npm/mongodb/2.1.7/manifest.n4mf
+++ b/npm/mongodb/2.1.7/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: mongodb
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.0.1-incomplete
 VendorId: npm
 Output: "."

--- a/npm/morgan/1.9.0/manifest.n4mf
+++ b/npm/morgan/1.9.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: morgan
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.9.0
 VendorId: npm
 Output: "."

--- a/npm/next/5.0.0/manifest.n4mf
+++ b/npm/next/5.0.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: next
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 5.0.0
 VendorId: npm
 Output: "."

--- a/npm/node-uuid/1.4.7-incomplete/manifest.n4mf
+++ b/npm/node-uuid/1.4.7-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: node-uuid
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.4.7-incomplete
 VendorId: npm
 Output: "."

--- a/npm/nomnom-patched/1.8.1/manifest.n4mf
+++ b/npm/nomnom-patched/1.8.1/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: nomnom-patched
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.8.1
 VendorId: npm
 Output: "."

--- a/npm/nuka-carousel/3.0.0/manifest.n4mf
+++ b/npm/nuka-carousel/3.0.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: nuka-carousel
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 3.0.0
 VendorId: npm
 Output: "."

--- a/npm/pdf-parse/1.0.8/manifest.n4mf
+++ b/npm/pdf-parse/1.0.8/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: pdf-parse
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.0.8
 VendorId: npm
 Output: "."

--- a/npm/rc/1.2.2/manifest.n4mf
+++ b/npm/rc/1.2.2/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: rc
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.2.2
 VendorId: npm
 Output: "."

--- a/npm/react-body-classname/1.2.0/manifest.n4mf
+++ b/npm/react-body-classname/1.2.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: react-body-classname
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.2.0
 VendorId: npm
 Output: "."

--- a/npm/react-document-title/2.0.3/manifest.n4mf
+++ b/npm/react-document-title/2.0.3/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: react-document-title
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 2.0.3
 VendorId: npm
 Output: "."

--- a/npm/react-dom/16.2.0/manifest.n4mf
+++ b/npm/react-dom/16.2.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: react-dom
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 16.2.0
 VendorId: npm
 Output: "."

--- a/npm/react-intl/2.4.0/manifest.n4mf
+++ b/npm/react-intl/2.4.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: react-intl
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 2.4.0
 VendorId: npm
 Output: "."

--- a/npm/react-markdown/2.5.1/manifest.n4mf
+++ b/npm/react-markdown/2.5.1/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: react-markdown
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 2.5.1
 VendorId: npm
 Output: "."

--- a/npm/react-redux/5.0.6/manifest.n4mf
+++ b/npm/react-redux/5.0.6/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: react-redux
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 5.0.6
 VendorId: npm
 Output: "."

--- a/npm/react-transition-group/1.2.1/manifest.n4mf
+++ b/npm/react-transition-group/1.2.1/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: react-transition-group
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.2.1
 VendorId: npm
 Output: "."

--- a/npm/react/16.2.0/manifest.n4mf
+++ b/npm/react/16.2.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: react
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 16.2.0
 VendorId: npm
 Output: "."

--- a/npm/redux-promise/0.5.3/manifest.n4mf
+++ b/npm/redux-promise/0.5.3/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: redux-promise
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 0.5.3
 VendorId: npm
 Output: "."

--- a/npm/redux-saga/0.16.0/manifest.n4mf
+++ b/npm/redux-saga/0.16.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: redux-saga
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 0.16.0
 VendorId: npm
 Output: "."

--- a/npm/redux/3.7.2/manifest.n4mf
+++ b/npm/redux/3.7.2/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: redux
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 3.7.2
 VendorId: npm
 Output: "."

--- a/npm/selenium-webdriver/3.6.0/manifest.n4mf
+++ b/npm/selenium-webdriver/3.6.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: selenium-webdriver
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 3.6.0
 VendorId: npm
 Output: "."

--- a/npm/serve-index/1.9.1/manifest.n4mf
+++ b/npm/serve-index/1.9.1/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: serve-index
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 1.9.1
 VendorId: npm
 Output: "."

--- a/npm/sharp/0.18.4/manifest.n4mf
+++ b/npm/sharp/0.18.4/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: sharp
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 0.18.4
 VendorId: npm
 Output: "."

--- a/npm/sinon/4.1.2/manifest.n4mf
+++ b/npm/sinon/4.1.2/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: sinon
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 4.1.2
 VendorId: npm
 Output: "."

--- a/npm/uuid/3.0.1-incomplete/manifest.n4mf
+++ b/npm/uuid/3.0.1-incomplete/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: uuid
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 3.0.1-incomplete
 VendorId: npm
 Output: "."

--- a/npm/v8-profiler/5.7.0/manifest.n4mf
+++ b/npm/v8-profiler/5.7.0/manifest.n4mf
@@ -1,5 +1,5 @@
 ProjectId: v8-profiler
-ProjectType: library
+ProjectType: validation
 ProjectVersion: 5.7.0
 VendorId: npm
 Output: "."


### PR DESCRIPTION
see https://github.com/eclipse/n4js/pull/807

In this PR the project type is changed to `validation`. This project type is made for projects that do not need the transpiler. (Hence) this project type will not show an error when output folder and source folder conflict with each other.

Note: The project type validation was merged to N4JS on **15th of May 2018**.