### PR TITLE
GH-1079: Fix dependency in package.json file + add .project file

### DIFF
--- a/npm/base64-js/1.3.0/.project
+++ b/npm/base64-js/1.3.0/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>base64-js-n4jsd</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/npm/base64-js/1.3.0/package-fragment.json
+++ b/npm/base64-js/1.3.0/package-fragment.json
@@ -1,5 +1,11 @@
 {
-  "n4js": {
-    "moduleLoader": "commonjs"
-  }
+    "dependencies": {
+        "n4js-runtime-esnext": "*"
+    },
+    "n4js": {
+        "moduleLoader": "commonjs",
+        "requiredRuntimeLibraries": [
+            "n4js-runtime-esnext"
+        ]
+    }
 }

--- a/npm/base64-js/1.3.0/package.json
+++ b/npm/base64-js/1.3.0/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "base64-js-n4jsd",
 	"version": "1.3.0",
+	"dependencies": {
+		"n4js-runtime-esnext": "*"
+	},
 	"n4js": {
 		"projectType": "definition",
 		"definesPackage": "base64-js",
@@ -11,6 +14,9 @@
 				"."
 			]
 		},
-		"moduleLoader": "commonjs"
+		"moduleLoader": "commonjs",
+		"requiredRuntimeLibraries": [
+			"n4js-runtime-esnext"
+		]
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse/n4js/issues/1079.

In this PR, I declared an explicit dependency on `n4js-runtime-esnext` in order to fix validation issues in the `index.n4jsd` of the definition project.